### PR TITLE
fixing issue #7

### DIFF
--- a/src/main/java/org/openbaton/faultmanagement/core/pm/PolicyManagerImpl.java
+++ b/src/main/java/org/openbaton/faultmanagement/core/pm/PolicyManagerImpl.java
@@ -66,8 +66,10 @@ public class PolicyManagerImpl implements PolicyManager {
     log.info("The NSR" + nsr.getName() + " needs fault management monitoring");
     List<VirtualNetworkFunctionRecord> vnfrRequiringFaultManagement =
         getVnfrRequiringFaultManagement(nsr);
-
+    for (VirtualNetworkFunctionRecord vnfr : vnfrRequiringFaultManagement)
+      eventSubscriptionManger.subscribe(vnfr, Action.HEAL);
     saveManagedNetworkServiceRecord(nsr);
+
     eventSubscriptionManger.subscribe(nsr, Action.HEAL);
     monitoringManager.startMonitorNS(nsr);
     highAvailabilityManager.configureRedundancy(nsr);

--- a/src/main/java/org/openbaton/faultmanagement/receivers/OpenbatonEventReceiver.java
+++ b/src/main/java/org/openbaton/faultmanagement/receivers/OpenbatonEventReceiver.java
@@ -58,7 +58,7 @@ public class OpenbatonEventReceiver {
       boolean isNSRManaged = policyManager.isNSRManaged(nsr.getId());
       if (isNSRManaged) {
         if (openbatonEvent.getAction() == Action.HEAL) {
-          logger.debug("Recoveri action finished on nsr:" + nsr.getId());
+          logger.debug("Recovery action finished on nsr:" + nsr.getId());
           recoveryActionFinishedOnNsr(nsr.getId());
         }
       } else policyManager.manageNSR(nsr);
@@ -73,7 +73,14 @@ public class OpenbatonEventReceiver {
     try {
       openbatonEvent = getOpenbatonEvent(message);
       logger.debug("Received VNF event with action: " + openbatonEvent.getAction());
-      //VirtualNetworkFunctionRecord vnfr = getVnfrFromPayload(openbatonEvent.getPayload());
+      VirtualNetworkFunctionRecord vnfr = getVnfrFromPayload(openbatonEvent.getPayload());
+      boolean isNSRManaged = policyManager.isNSRManaged(vnfr.getParent_ns_id());
+      if (isNSRManaged) {
+        if (openbatonEvent.getAction() == Action.HEAL) {
+          logger.debug("Recovery action finished on vnfr:" + vnfr.getName());
+          recoveryActionFinishedOnVnfr(vnfr.getId());
+        }
+      }
     } catch (Exception e) {
       if (logger.isDebugEnabled()) logger.error(e.getMessage(), e);
       else logger.error(e.getMessage());

--- a/src/main/resources/rules/fault_resolution.drl
+++ b/src/main/resources/rules/fault_resolution.drl
@@ -20,14 +20,31 @@ import org.openbaton.faultmanagement.core.ham.interfaces.HighAvailabilityManager
 global org.slf4j.Logger logger
 global HighAvailabilityManager highAvailabilityManager
 
+declare RecoveryActionStatus
+ @role(event)
+ @expires(1m)
+end
+
 rule "Recovery action finished in nsr"
     when
        recoveryActionEnd : RecoveryAction(status == RecoveryActionStatus.FINISHED, nsrId != null, $nsrId : nsrId)
        recoveryActionActual : RecoveryAction(status == RecoveryActionStatus.IN_PROGRESS, nsrId != null , nsrId == $nsrId)
     then
-        logger.info("The recovery action " + recoveryActionActual.getRecoveryActionType() + " is finished in the ns with id: "+$nsrId);
+        logger.info("The recovery action " + recoveryActionActual.getRecoveryActionType() + " is finished in the NSR with id: "+$nsrId);
 
         highAvailabilityManager.cleanFailedInstances($nsrId);
+
+        delete(recoveryActionActual);
+        delete(recoveryActionEnd);
+end
+
+
+rule "Recovery action finished in vnfr"
+    when
+       recoveryActionEnd : RecoveryAction(status == RecoveryActionStatus.FINISHED, vnfrId != null, $vnfrId : vnfrId)
+       recoveryActionActual : RecoveryAction(status == RecoveryActionStatus.IN_PROGRESS, vnfrId != null, vnfrId == $vnfrId)
+    then
+        logger.info("The recovery action " + recoveryActionActual.getRecoveryActionType() + " is finished in the VNFR with id: "+$vnfrId);
 
         delete(recoveryActionActual);
         delete(recoveryActionEnd);

--- a/src/main/resources/rules/vnfm_fault_correlator.drl
+++ b/src/main/resources/rules/vnfm_fault_correlator.drl
@@ -86,7 +86,7 @@ rule "Recovery action still in progress"
         a : VRAlarm( )
         RecoveryAction(status == RecoveryActionStatus.IN_PROGRESS)
     then
-        logger.warn("Received vr Alarm bu a recovery action is still in progress");
+        logger.warn("Received vr Alarm but a recovery action is still in progress");
 end
 
 rule "A VR alarm is cleared"


### PR DESCRIPTION
FMS was not enabled to receive VNF events so it could not clear the state "recovery action in progress". 
It caused the following alarms to get ignored. Now the state is correctly cleared, moreover the recovery action is managed as an event which expires after 1 minute.